### PR TITLE
Only Mark Node Schedulable If Agent Marked As Unschedulable 

### DIFF
--- a/doc/labels-and-annotations.md
+++ b/doc/labels-and-annotations.md
@@ -41,3 +41,4 @@ A few labels may be set directly by admins to customize behavior. These are call
 | status | UPDATE_STATUS_IDLE | update-agent | Reflects the `update_engine` CurrentOperation status value |
 | new-version       | 0.0.0      | update-agent | Reflects the `update_engine` NewVersion status value |
 | last-checked-time | 1501621307 | update-agent | Reflects the `update_engine` LastCheckedTime status value |
+| agent-made-unschedulable | true/false | update-agent | Indicates if the agent made the node unschedulable. If false, something other than the agent made the node unschedulable |

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -123,7 +123,7 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 			return err
 		}
 	} else {
-		glog.Info("Skipping marking node as schedulable -- node was unschedulable prior to update reboot")
+		glog.Info("Skipping marking node as schedulable -- node was marked unschedulable by an external source")
 	}
 
 	// watch update engine for status updates

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -99,8 +99,9 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 	// set coreos.com/update1/reboot-in-progress=false and
 	// coreos.com/update1/reboot-needed=false
 	anno := map[string]string{
-		constants.AnnotationRebootInProgress: constants.False,
-		constants.AnnotationRebootNeeded:     constants.False,
+		constants.AnnotationRebootInProgress:       constants.False,
+		constants.AnnotationRebootNeeded:           constants.False,
+		constants.AnnotationAgentMadeUnschedulable: constants.False,
 	}
 	labels := map[string]string{
 		constants.LabelRebootNeeded: constants.False,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -170,11 +170,9 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 			return err
 		}
 
-		// set constants.AnnotationRebootInProgress and drain self
 		anno = map[string]string{
 			constants.AnnotationAgentMadeUnschedulable: constants.True,
 		}
-
 		if err := k8sutil.SetNodeAnnotations(k.nc, k.node, anno); err != nil {
 			return err
 		}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -164,7 +164,7 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 	// ('any pods that are neither mirror pods nor managed by
 	// ReplicationController, ReplicaSet, DaemonSet or Job')
 
-	if alreadyUnschedulable == false {
+	if !alreadyUnschedulable {
 		glog.Info("Marking node as unschedulable")
 		if err := k8sutil.Unschedulable(k.nc, k.node, true); err != nil {
 			return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -52,6 +52,9 @@ const (
 	// It is an opaque string, but might be semver.
 	AnnotationNewVersion = Prefix + "new-version"
 
+	// Ket set by update-agent to indicate it was responsible for making node unschedulable
+	AnnotationAgentMadeUnschedulable = Prefix + "agent-made-unschedulable"
+
 	// Keys set to true when the operator is waiting for configured annotation
 	// before and after the reboot repectively
 	LabelBeforeReboot = Prefix + "before-reboot"

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -35,6 +35,22 @@ func NodeAnnotationCondition(selector fields.Selector) watch.ConditionFunc {
 	}
 }
 
+// GetNodeRetry gets a node object, retrying up to DefaultBackoff number of times if it fails
+func GetNodeRetry(nc v1core.NodeInterface, node string) (*v1api.Node, error) {
+	var apiNode *v1api.Node
+	err := RetryOnError(DefaultBackoff, func() error {
+		n, getErr := nc.Get(node, v1meta.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("failed to get node %q: %v", node, getErr)
+		}
+
+		apiNode = n
+		return nil
+	})
+
+	return apiNode, err
+}
+
 // UpdateNodeRetry calls f to update a node object in Kubernetes.
 // It will attempt to update the node by applying f to it up to DefaultBackoff
 // number of times.

--- a/pkg/k8sutil/retry.go
+++ b/pkg/k8sutil/retry.go
@@ -79,3 +79,21 @@ func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
 	}
 	return err
 }
+
+// RetryOnError retries a function repeatedly with the specified backoff until it succeeds or times out
+func RetryOnError(backoff wait.Backoff, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		lastErr := fn()
+		if lastErr == nil {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	if err == wait.ErrWaitTimeout {
+		err = lastErr
+	}
+	return err
+}

--- a/pkg/k8sutil/retry.go
+++ b/pkg/k8sutil/retry.go
@@ -85,11 +85,8 @@ func RetryOnError(backoff wait.Backoff, fn func() error) error {
 	var lastErr error
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		lastErr := fn()
-		if lastErr == nil {
-			return true, nil
-		}
 
-		return false, nil
+		return lastErr == nil, nil
 	})
 
 	if err == wait.ErrWaitTimeout {


### PR DESCRIPTION
This PR makes it so a node is only marked schedulable if the agent had marked it unschedulable. This fixes an issue where an agent was erroneously marking a node schedulable on pod restart. 